### PR TITLE
Pin `ocaml` version better

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 3.1)
 
 (name type_eq)
+
 (version 0.0.1)
 
 (generate_opam_files true)
@@ -20,6 +21,7 @@
  (name type_eq)
  (synopsis "Type equality proofs for OCaml 4")
  (depends
-  ocaml
+  (ocaml
+   (>= 4.03))
   dune
   (alcotest :with-test)))

--- a/type_eq.opam
+++ b/type_eq.opam
@@ -10,11 +10,12 @@ license: "MIT"
 homepage: "https://github.com/skolemlabs/type_eq"
 bug-reports: "https://github.com/skolemlabs/type_eq/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.03"}
   "dune" {>= "3.1"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
+dev-repo: "git+https://github.com/skolemlabs/type_eq.git"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -25,8 +26,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version >= "4.08"}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/skolemlabs/type_eq.git"

--- a/type_eq.opam.template
+++ b/type_eq.opam.template
@@ -1,0 +1,14 @@
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & ocaml:version >= "4.08"}
+    "@doc" {with-doc}
+  ]
+]


### PR DESCRIPTION
__[SKO-2352] Pin `ocaml` version better__

This change adds some OCaml version constraints to `dune-project` in order to better convey which versions of OCaml this library is compatible with.

Turns out, without Alcotest, this library runs on OCaml 4.03+, which is nice!

I'm planning on tagging this commit as `0.0.1` after merge, which may affect the source tarball. If this happens this `nix` package will break.

This should be OK -- I doubt anybody is depending on the `nix` package yet -- but I'll need to update the hash of the source tarball in `nixpgks` after this.

Lesson learned: it's best to release to `nixpkgs` after the `opam` release has completed.